### PR TITLE
Began new "production" installation docs

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -23,8 +23,8 @@ Dependencies
 
 .. _installation:
 
-Basic Installation
-~~~~~~~~~~~~~~~~~~
+Standard Installation
+~~~~~~~~~~~~~~~~~~~~~
 
 Install system requirements:
 

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -65,6 +65,9 @@ Install mongodb.
 Please check the `mongodb website <https://docs.mongodb.org/manual/installation/>`_ for installation
 instructions on different Linux distributions.
 
+*This is the end of the standard installation, you may now proceed with :ref:`Configuration`*
+
+
 Production Installation
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -24,7 +24,7 @@ Dependencies
 .. _installation:
 
 Basic Installation
-------------------
+~~~~~~~~~~~~~~~~~~
 
 Install system requirements:
 
@@ -66,7 +66,7 @@ Please check the `mongodb website <https://docs.mongodb.org/manual/installation/
 instructions on different Linux distributions.
 
 Production Installation
------------------------
+~~~~~~~~~~~~~~~~~~~~~~~
 
 
 Installing dependencies
@@ -135,24 +135,7 @@ Installation of cve-search in the home directory of the user `cve`
     
     exit
 
-
-Configure UWSGI
-
-.. code-block:: bash
-
-    sudo cat /opt/cve/cve-search/etc/wsgi.ini.sample /etc/uwsgi/apps-available/cve-search.ini
     
-    sudo ln -s /etc/uwsgi/apps-available/cve-search.ini /etc/uwsgi/apps-enabled/
-    
-    
-Confgiure NGINX
-.. code-block:: bash
-    
-    sudo cat /opt/cve/cve-search/etc/nginx.conf.sample /etc/nginx/sites-available/cve-search.conf
-    
-    sudo ln -s /etc/nginx/sites-available/cve-search.conf /etc/nginx/sites-enabled/
-
-
 Configuration
 -------------
 By default CVE-Search takes assumptions on certain configuration aspects of the application. These defaults are noted in

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -76,6 +76,33 @@ Installing dependencies
     cat requirements.system requirements.prod | sudo xargs apt-get install -y
 
 
+Install mongodb.
+
+.. code-block:: bash
+
+    wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | sudo apt-key add -
+
+    echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.4.list
+
+    sudo apt-get update
+
+    sudo apt-get install -y mongodb-org
+
+    sudo systemctl daemon-reload
+
+    sudo systemctl start mongod
+
+    # Verify status of mongodb
+    sudo systemctl status mongod
+
+    # if all is ok, enable mongodb to start on system startup
+    sudo systemctl enable mongod
+
+
+Please check the `mongodb website <https://docs.mongodb.org/manual/installation/>`_ for installation
+instructions on different Linux distributions.
+
+
 Create a dedicated, unprivileged, user to run the cve-search service
 
 .. code-block:: bash

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -70,16 +70,21 @@ Production Installation
 
 
 Installing additional dependencies
+
 .. code-block:: bash
 
     sudo apt install uwsgi uwsgi-core uwsgi-plugin-python3 python3-virtualenv nginx
 
+
 Create a dedicated, unprivileged, user to run the cve-search service
+
 .. code-block:: bash
 
     sudo adduser cve --home /opt/cve
 
+
 Create and activate a python virtual environment called *cve-env*
+
 .. code-block:: bash
 
     sudo su - cve

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -23,8 +23,8 @@ Dependencies
 
 .. _installation:
 
-Installation
-------------
+Basic Installation
+------------------
 
 Install system requirements:
 
@@ -64,6 +64,43 @@ Install mongodb.
 
 Please check the `mongodb website <https://docs.mongodb.org/manual/installation/>`_ for installation
 instructions on different Linux distributions.
+
+Production Installation
+-----------------------
+
+
+Installing additional dependencies
+.. code-block:: bash
+    sudo apt install uwsgi uwsgi-core uwsgi-plugin-python3 python3-virtualenv nginx
+
+Create a dedicated, unprivileged, user to run the cve-search service
+.. code-block:: bash
+    sudo adduser cve --home /opt/cve
+
+Create and activate a python virtual environment called *cve-env*
+.. code-block:: bash
+    sudo su - cve
+    virtualenv cve-env
+    source ./cve-env/bin/activate
+
+Installation of cve-search in the home directory of the user `cve`
+.. code-block:: bash
+    cd
+    git clone https://github.com/cve-search/cve-search.git
+    cd cve-search
+    pip3 install -r requirements
+    exit
+
+Configure UWSGI
+.. code-block:: bash
+    sudo cat /opt/cve/cve-search/etc/wsgi.ini.sample /etc/uwsgi/apps-available/cve-search.ini
+    sudo ln -s /etc/uwsgi/apps-available/cve-search.ini /etc/uwsgi/apps-enabled/cve-search.ini
+    
+Confgiure NGINX
+.. code-block:: bash
+    sudo cat /opt/cve/cve-search/etc/nginx.conf.sample /etc/nginx/sites-available/cve-search.conf
+    sudo ln -s /etc/nginx/sites-available/cve-search.conf /etc/nginx/sites-enabled/cve-search.conf
+
 
 Configuration
 -------------

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -65,7 +65,7 @@ Install mongodb.
 Please check the `mongodb website <https://docs.mongodb.org/manual/installation/>`_ for installation
 instructions on different Linux distributions.
 
-*This is the end of the standard installation, you may now proceed with :ref:`Configuration`*
+*This is the end of the standard installation, you may now proceed with :ref:`configuration`*
 
 
 Production Installation

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -69,11 +69,11 @@ Production Installation
 -----------------------
 
 
-Installing additional dependencies
+Installing dependencies
 
 .. code-block:: bash
 
-    sudo apt install uwsgi uwsgi-core uwsgi-plugin-python3 python3-virtualenv nginx
+    cat requirements.system requirements.prod | sudo xargs apt-get install -y
 
 
 Create a dedicated, unprivileged, user to run the cve-search service

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -71,35 +71,54 @@ Production Installation
 
 Installing additional dependencies
 .. code-block:: bash
+
     sudo apt install uwsgi uwsgi-core uwsgi-plugin-python3 python3-virtualenv nginx
 
 Create a dedicated, unprivileged, user to run the cve-search service
 .. code-block:: bash
+
     sudo adduser cve --home /opt/cve
 
 Create and activate a python virtual environment called *cve-env*
 .. code-block:: bash
+
     sudo su - cve
+    
     virtualenv cve-env
+    
     source ./cve-env/bin/activate
+    
 
 Installation of cve-search in the home directory of the user `cve`
+
 .. code-block:: bash
+
     cd
+    
     git clone https://github.com/cve-search/cve-search.git
+    
     cd cve-search
+    
     pip3 install -r requirements
+    
     exit
 
+
 Configure UWSGI
+
 .. code-block:: bash
+
     sudo cat /opt/cve/cve-search/etc/wsgi.ini.sample /etc/uwsgi/apps-available/cve-search.ini
-    sudo ln -s /etc/uwsgi/apps-available/cve-search.ini /etc/uwsgi/apps-enabled/cve-search.ini
+    
+    sudo ln -s /etc/uwsgi/apps-available/cve-search.ini /etc/uwsgi/apps-enabled/
+    
     
 Confgiure NGINX
 .. code-block:: bash
+    
     sudo cat /opt/cve/cve-search/etc/nginx.conf.sample /etc/nginx/sites-available/cve-search.conf
-    sudo ln -s /etc/nginx/sites-available/cve-search.conf /etc/nginx/sites-enabled/cve-search.conf
+    
+    sudo ln -s /etc/nginx/sites-available/cve-search.conf /etc/nginx/sites-enabled/
 
 
 Configuration

--- a/docs/source/webgui/webgui.rst
+++ b/docs/source/webgui/webgui.rst
@@ -201,7 +201,7 @@ Configure cve-search as a UWSGI app listening on a unix socket, and enable the a
 
 
 
-Disable NGINX's default config, and confgiure proxying connections to the uwsgi socket
+Disable NGINX's default config, and configure proxying connections to the uwsgi socket
 
 .. code-block:: bash
     

--- a/docs/source/webgui/webgui.rst
+++ b/docs/source/webgui/webgui.rst
@@ -174,6 +174,8 @@ When users surf to your website, they will get a warning, and they will have to 
 Starting and stopping the web-server
 ####################################
 
+Standard Installation
+---------------------
 Once you set up the configurations.ini file how you want it to be, you can start the webserver by simply
 running `python3 web/index.py`. To stop the server, you can simply press the **CTRL+C** combination.
 
@@ -182,6 +184,50 @@ Alternatively, on Linux, you can start the server by running `nohup python3 web/
 run in the background. However, this makes it so you cannot use the **CTRL+C** combination. Instead, you will have to
 find the processes related to the web-server, by using `ps aux | grep web/index.py`. Then kill them using the
 `kill -15` command on all the processes related to the server.
+
+Production Installation
+-----------------------
+
+Configure cve-search as a UWSGI app listening on a unix socket, and enable the app to start at boot.
+
+.. code-block:: bash
+
+    sudo cat /opt/cve/cve-search/etc/wsgi.ini.sample /etc/uwsgi/apps-available/cve-search.ini
+    
+    sudo ln -s /etc/uwsgi/apps-available/cve-search.ini /etc/uwsgi/apps-enabled/
+    
+    sudo systemctl restart uwsgi
+    
+
+
+
+Disable NGINX's default config, and confgiure proxying connections to the uwsgi socket
+
+.. code-block:: bash
+    
+    sudo rm /etc/nginx/sites-enabled/default
+    
+    sudo cat /opt/cve/cve-search/etc/nginx.conf.sample /etc/nginx/sites-available/cve-search.conf
+    
+    sudo ln -s /etc/nginx/sites-available/cve-search.conf /etc/nginx/sites-enabled/
+
+    sudo systemctl restart nginx
+    
+
+Visit `http://127.0.0.1/MOUNTY/MC/MOUNT/`
+
+
+App mounting (base_url)
+~~~~~~~~~~~~~~~~~~~
+
+When running cve-search under a 'production installation', a `base_url` can be configured through minor customisation of `web/wsgi.py`.  By default, the production installation is mounted at `/MOUNTY/MC/MOUNT`.
+
+NOTE:
+~~~~~
+
+* When running cve-search using UWSGI and NGINX, cve-search's `SSL`, `host`, and `port` configuration settings are ignored. SSL should instead be configured via NGINX. 
+
+
 
 Using the web-server
 ####################

--- a/etc/nginx.conf.sample
+++ b/etc/nginx.conf.sample
@@ -1,0 +1,8 @@
+server {
+        listen 80;
+        
+        location / {
+               uwsgi_pass unix:/var/run/uwsgi/app/cve-search/socket;
+       }
+
+}

--- a/etc/wsgi.ini.sample
+++ b/etc/wsgi.ini.sample
@@ -5,6 +5,7 @@ chdir = /opt/cve/cve-search/
 callable = app
 module = web.wsgi:app
 plugins = python3
+virtualenv = /opt/cve/cve-env/
 socket = /var/run/uwsgi/app/cve-search/socket
 chmod-socket = 755
 

--- a/etc/wsgi.ini.sample
+++ b/etc/wsgi.ini.sample
@@ -5,7 +5,7 @@ chdir = /opt/cve/cve-search/
 callable = app
 module = web.wsgi:app
 plugins = python3
-virtualenv = /opt/cve/cve-env/
+virtualenv = /opt/cve/cve-env
 socket = /var/run/uwsgi/app/cve-search/socket
 chmod-socket = 755
 

--- a/requirements.prod
+++ b/requirements.prod
@@ -1,0 +1,5 @@
+uwsgi
+uwsgi-core
+uwsgi-plugin-python3
+python3-virtualenv
+nginx


### PR DESCRIPTION
Updated the Installation and webgui documentation to describe a (more) production style environment using UWSGI and NGINX.

Existing instructions have been re-titled as "Standard Installation", and a new "Production Installation" section has been added.  Production installation differs from standard in that it involves:
 - the creation and use of a dedicated user to run cve-search
 - the use of a python3 virtual environment
 - NGINX as a reverse proxy
 - UWSGI running (arbitrarily) 10 process in parallel

(tested and running on Ubuntu 20.04)